### PR TITLE
Fix typo 

### DIFF
--- a/content/design.md
+++ b/content/design.md
@@ -82,7 +82,7 @@ Some examples of specifiers are:
   data Coord2D: x U64, y U64
   ```
   where `data Coord2D` is a *data type declaration*, separated with colon from the type information, 
-  which is `x U64, y U65`. Data type specifiers contain no body.
+  which is `x U64, y U64`. Data type specifiers contain no body.
 - value specifier:
   ```
   val value: U8 := 5
@@ -155,7 +155,7 @@ makes 2D coordinate as a product of two 32-bit integers. Likewise, a co-product 
 
 #### Projection operators
 
-Projection operators <code>&nbsp;</code> and `.` allow to call a function providing it with arguments. The use of these
+Projection operators <code>&nbsp;</code> (space) and `.` (dot) allow to call a function providing it with arguments. The use of these
 two forms depends on the function type and a number of its arguments. There are two types of functions, which affect the
 operator: prefix functions (declared using `fx` keyword) and infix functions (declared with `infx` keyword). For prefix
 operators one calls a function (i.e. does projection) by putting function argument after the function name, separating


### PR DESCRIPTION
I started read entire documentation to understand the design behind cation and contractum.

Just a suggestion: I added parentheses with the "character name" to help the reader identify it. At first, I thought you had not included the character, but when I inspected the HTML, I discovered you refer to a 'space'.

As you emphasized the use of the space character in the text, I just wanted to ask a question:

Would there be any difference in using a single space, succession of spaces or even tabs?

I ask this because some text editors replace spaces with tabs, which can even generate confusion among programmers, where they add a tab instead of a space.

Thanks